### PR TITLE
Support custom Settings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Properties" : {
         "<a href="#name" title="Name">Name</a>" : <i>String</i>,
         "<a href="#partitionscount" title="PartitionsCount">PartitionsCount</a>" : <i>Integer</i>,
+        "<a href="#settings" title="Settings">Settings</a>" : <i>Map</i>,
         "<a href="#replicationfactor" title="ReplicationFactor">ReplicationFactor</a>" : <i>Integer</i>,
         "<a href="#bootstrapservers" title="BootstrapServers">BootstrapServers</a>" : <i>String</i>,
         "<a href="#securityprotocol" title="SecurityProtocol">SecurityProtocol</a>" : <i>String</i>,
@@ -32,6 +33,7 @@ Type: EWS::Kafka::Topic
 Properties:
     <a href="#name" title="Name">Name</a>: <i>String</i>
     <a href="#partitionscount" title="PartitionsCount">PartitionsCount</a>: <i>Integer</i>
+    <a href="#settings" title="Settings">Settings</a>: <i>Map</i>
     <a href="#replicationfactor" title="ReplicationFactor">ReplicationFactor</a>: <i>Integer</i>
     <a href="#bootstrapservers" title="BootstrapServers">BootstrapServers</a>: <i>String</i>
     <a href="#securityprotocol" title="SecurityProtocol">SecurityProtocol</a>: <i>String</i>
@@ -64,6 +66,14 @@ Number of partitions for the new Kafka topic
 _Required_: Yes
 
 _Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Settings
+
+_Required_: No
+
+_Type_: Map
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/ews-kafka-topic.json
+++ b/ews-kafka-topic.json
@@ -20,6 +20,9 @@
             "type": "integer",
             "description": "Number of partitions of the Kafka topic"
         },
+        "Settings": {
+            "type": "object"
+        },
         "ReplicationFactor": {
             "type": "integer",
             "default": 3,

--- a/sam-tests/create-custom-resource.json
+++ b/sam-tests/create-custom-resource.json
@@ -10,6 +10,11 @@
         "PartitionsCount": 6,
         "ReplicationFactor": 1,
         "BootstrapServers": "192.168.72.21:9092",
-        "SecurityProtocol": "PLAINTEXT"
+        "SecurityProtocol": "PLAINTEXT",
+        "Settings": {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": 1209600000,
+            "retention.ms": 15778800000
+        }
     }
 }

--- a/sam-tests/create.json
+++ b/sam-tests/create.json
@@ -12,7 +12,12 @@
             "PartitionsCount": 6,
             "ReplicationFactor": 1,
             "BootstrapServers": "192.168.72.21:9092",
-            "SecurityProtocol": "PLAINTEXT"
+            "SecurityProtocol": "PLAINTEXT",
+            "Settings": {
+                "cleanup.policy": "compact,delete",
+                "min.compaction.lag.ms": 1209600000,
+                "retention.ms": 15778800000
+            }
         },
         "logicalResourceIdentifier": "ANewKafkaTopic"
     },

--- a/src/ews_kafka_topic/custom_resource.py
+++ b/src/ews_kafka_topic/custom_resource.py
@@ -80,6 +80,9 @@ class KafkaTopic(ResourceProvider):
                     "default": 1,
                     "description": "Kafka topic replication factor",
                 },
+                "Settings": {
+                    "type": "object"
+                },
                 "BootstrapServers": {
                     "type": "string",
                     "minLength": 3,
@@ -191,6 +194,7 @@ class KafkaTopic(ResourceProvider):
                 self.cluster_info,
                 replication_factor=self.get("ReplicationFactor"),
                 is_confluent=self.get("IsConfluentKafka"),
+                settings=self.get("Settings")
             )
             self.physical_resource_id = topic_name
             self.set_attribute("Name", self.get("Name"))

--- a/src/ews_kafka_topic/models.py
+++ b/src/ews_kafka_topic/models.py
@@ -42,6 +42,7 @@ class ResourceModel(BaseModel):
     Name: Optional[str]
     PartitionsCount: Optional[int]
     Partitions: Optional[int]
+    Settings: Optional[MutableMapping[str, Any]]
     ReplicationFactor: Optional[int]
     BootstrapServers: Optional[str]
     SecurityProtocol: Optional[str]
@@ -63,6 +64,7 @@ class ResourceModel(BaseModel):
             Name=json_data.get("Name"),
             PartitionsCount=json_data.get("PartitionsCount"),
             Partitions=json_data.get("Partitions"),
+            Settings=json_data.get("Settings"),
             ReplicationFactor=json_data.get("ReplicationFactor"),
             BootstrapServers=json_data.get("BootstrapServers"),
             SecurityProtocol=json_data.get("SecurityProtocol"),
@@ -75,3 +77,5 @@ class ResourceModel(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _ResourceModel = ResourceModel
+
+

--- a/src/ews_kafka_topic/topics_management.py
+++ b/src/ews_kafka_topic/topics_management.py
@@ -49,7 +49,7 @@ def keypresent(x, y):
 
 
 def create_new_kafka_topic(
-    name, partitions, cluster_info, replication_factor=None, is_confluent=False
+    name, partitions, cluster_info, replication_factor=None, is_confluent=False, settings=None
 ):
     """
     Function to create new Kafka topic
@@ -69,7 +69,7 @@ def create_new_kafka_topic(
     else:
         try:
             admin_client = KafkaAdminClient(**cluster_info)
-            topic = NewTopic(name, partitions, replication_factor)
+            topic = NewTopic(name, partitions, replication_factor, topic_configs=settings)
             admin_client.create_topics([topic])
             return name
         except errors.TopicAlreadyExistsError:


### PR DESCRIPTION
Support for custom Settings as generated by aws-cfn-kafka-admin-provider.

Not tested on AWS but working against local broker